### PR TITLE
Adding support to gracefully shutdown

### DIFF
--- a/cmd/icalm-server/main.go
+++ b/cmd/icalm-server/main.go
@@ -103,8 +103,17 @@ func main() {
 
 	log.Println("Shutting down")
 
+	//closing all the listening sockets
 	for _, cs := range toclose {
 		cs.Close()
 	}
+
+	log.Println("Waiting for clients to disconnect")
+
+	//wait until all clients have finished their business
+	for _, serv := range servers {
+		serv.Wg.Wait()
+	}
+
 
 }


### PR DESCRIPTION
New Waitgroup per lineprotocol server that is used to wait for all clients to finish and disconnect. As inactive clients are disconnected after 60s anyway no timeout is needed.